### PR TITLE
Firestoreから取得したトピックデータをシャッフルページでも利用

### DIFF
--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -1,134 +1,49 @@
 import { useCallback, useState, useEffect } from "react";
 import Head from "next/head";
+import { useTopics } from "../../lib/useTopics";
 
 export const Main = () => {
-  const [topic, setTopic] = useState("なにをやねん");
-  const [isDefault, setIsDefault] = useState(true);
-
-  // todo 話題の切り替え機能
-  const defaultTopics: Array<string> = [
-    "最近あった面白いこと",
-    "最近ハッピーだったこと",
-    "最近失敗したこと",
-    "１ヶ月の休みが会ったらなにする？",
-    "１億円あったらどうする？",
-    "休日はどう過ごしている？",
-    "こういう人は許せない",
-    "朝起きて最初にすること",
-    "人生で最も乗っていたときの話",
-    "無人島に持っていくもの３つ",
-    "もう一度人生をやるとしたらなにになる？",
-    "50歳のときにどうなっていたい？",
-    "人生最大の失敗",
-    "最後に泣いたのは？",
-    "１年前の今頃なにしてた？",
-    "５年前の今頃なにしてた？",
-    "３年前の今頃なにしてた？",
-    "なぞに覚えている一番小さい頃の思い出",
-    "小さい頃の夢",
-    "最近買った高価なもの",
-    "子供に付けたい名前",
-    "すべらない話",
-    "今ハマっていること",
-    "永遠の何歳でいたい？",
-    "今の生活の中での一番の楽しみ",
-    "昔学校で流行った遊び",
-    "大学時代に戻ったらやりたいこと",
-    "職場にいるおもろい人",
-    "最近感じた青春",
-    "自分の中での流行語",
-    "最近「自分天才か!」と感じたこと",
-    "自分の好きなところ",
-    "もう一度新卒就活するとしたらどこにいく？",
-    "自由に職業選べるとしたらなにやる",
-    "自分に子供ができたらなにになって欲しい？",
-    "何か新しく始めたいことは？",
-    "無人島に持っていくもの１つ",
-  ];
-  const q36: Array<string> = [
-    "この世界の誰でもディナーに呼べるとしたら、誰を招待しますか？",
-    "有名になりたいですか？　どんな方法で？",
-    "電話をかける前に、何を話すかリハーサルすることがありますか？　なぜ？",
-    "あなたにとって「完璧な日」とはどんな日ですか？",
-    "最後に1人で歌を歌ったのはいつですか？　また、誰かに対して歌ったのはいつですか？",
-    "あなたは90才まで生きられ、その上、最後の60年間を「30才の肉体」か、「30才の精神」を保つことができます。どちらを選びますか？",
-    "自分がどんな死に方をするか、何か予感はありますか？",
-    "自分と相手の共通点を、3つ挙げてください。",
-    "人生で最も感謝していることはなんですか？",
-    "自分の成長過程の一部を修正することができるなら、どんなことを変えたいですか？",
-    "4分間、あなたがこれまでどんな人生を歩んできたのか、できるだけ克明に説明して下さい。",
-    "明日の朝、目が覚めたときに何らかの才能や能力が身についています。どんな能力がいいですか？",
-    "もしも、「真実のあなた」や「あなたの人生」「将来」などを教えてくれる水晶があったら、どんなことが知りたいですか？",
-    "ずっと夢に見てきたことがありますか？　あるなら、なぜ実現させていないのでしょう？",
-    "これまでの人生で達成した、一番の偉業は何ですか？",
-    "友情において、もっとも価値のあることは何ですか？",
-    "一番大切な思い出は何ですか？",
-    "一番最悪な思い出は何ですか？",
-    "1年後に死ぬことが分かったとしたら、今の生き方を変えますか？　その理由は？",
-    "あなたにとって「友情」とはなんですか？",
-    "あなたの人生の中で、「愛・愛情」はどのような役割を果たしていますか？",
-    "相手の長所を、5つ挙げてください。お互い順番に、1つずつ述べて下さい。",
-    "あなたは家族と仲が良いですか？　子供時代は、他の人よりも幸せだと感じていましたか？",
-    "母親との関係をどう感じていますか？",
-    "「私たちは」で始まる文章で、今の状況を3回描写して下さい。例えば、「私たちはこの部屋にいて……と感じている」など。",
-    "「……を、共感できる人がいればいいのに」という文章を完成させてください。",
-    "もしも、今話している相手とより深い関係になるとして、あなたについて相手が知っておくべき重要なことは何ですか？",
-    "相手の良いところは何ですか？　初対面の人には言わないようなことを、挙げて下さい。",
-    "恥ずかしかった体験を、相手に話してみて下さい。",
-    "最後に、他人の前で泣いたのはいつですか？　1人で泣いたのはいつですか？",
-    "相手のどんなところが好きですか？",
-    "とても冗談にはできないほど、深刻なことは何ですか？",
-    "今夜死ぬとしたら、誰かに何かを告げなかったことで、一番の心残りは何ですか？　なぜ、そのことを言わなかったのですか？",
-    "大切なものが全て詰まった家が火事になってしまいました。家族とペットを助け出した後、何か一つだけ取りに行くことができます。何を取りに行きますか？　その理由は？",
-    "家族の中で、誰の死が一番悲しいですか？　その理由は？",
-    "個人的な問題を打ち明けて、相手からアドバイスを受けて下さい。また、その問題を抱えるあなたがどんな気持ちでいるのか、相手に想像・描写してもらって下さい。",
-  ];
+  const [topicLabel, setTopicLabel] = useState("なにをやねん");
+  const { getTopicsFromFirestore, topics } = useTopics();
 
   // 話題切り替え時に表示を初期化
   useEffect(() => {
-    setTopic("なにをやねん");
-  }, [isDefault]);
+    setTopicLabel("なにをやねん");
+  }, [setTopicLabel]);
+
+  // Firestore からトピックスを取得
+  useEffect(() => {
+    const unSubscription = getTopicsFromFirestore();
+    return () => unSubscription();
+  }, [getTopicsFromFirestore]);
 
   const onClickShuffle = useCallback(() => {
     // シャッフルされた話題を表示させる
-    if (isDefault) {
-      shuffleTopics(defaultTopics);
-    } else {
-      shuffleTopics(q36);
-    }
-  }, [defaultTopics, q36]);
-
-  const shuffleTopics = (topics: Array<string>) => {
     let topicNum = Math.floor(Math.random() * topics.length);
-    setTopic(topics[topicNum]);
-  };
+    setTopicLabel(topics[topicNum].content);
+  }, [topics, setTopicLabel]);
 
   return (
     <div className="mt-5 justify-center flex flex-col">
-      {/* TODO: レイアウトをきれいにする */}
       <Head>
-        <title>{isDefault ? "フツーの" : "36の質問"}</title>
+        <title>トピックる</title>
       </Head>
 
-      <h2 className="text-blue-400 font-bold text-2xl font-mono m-5 mt-3 max-w-lg text-center">
-        {isDefault ? "フツーの話題" : "36の質問"}
+      <h2 className="mx-auto text-blue-400 font-bold text-2xl font-mono m-5 mt-3 max-w-lg text-center">
+        フツーの話題
       </h2>
-
-      <p className="text-gray-600 text-xl font-bold  font-mono m-5 max-w-lg">
-        {topic === "なにをやねん" ? topic : `なにを？： ${topic}`}
+      {/*todo トピックの文字数が変わってもボタン位置が変わらないようにしたい*/}
+      <p className="text-center text-gray-600 text-xl font-bold  font-mono m-5 mx-auto">
+        {topicLabel === "なにをやねん"
+          ? topicLabel
+          : `なにを？： ${topicLabel}`}
       </p>
 
       <button
-        className="font-bold text-2xl bg-blue-400 py-2 px-4 rounded-xl text-white hover:bg-blue-300 m-5 mt-1"
+        className="w-1/2 font-bold text-2xl bg-blue-400 py-2 px-4 rounded-xl text-white hover:bg-blue-300 mx-auto mt-1"
         onClick={onClickShuffle}
       >
         ぷっしゅ
-      </button>
-      <button
-        className="font-bold text-2xl bg-yellow-500 hover:bg-yellow-300 py-2 px-4 rounded-xl text-white m-5 mt-0"
-        onClick={() => setIsDefault(!isDefault)}
-      >
-        トピックを変える
       </button>
     </div>
   );

--- a/src/components/TopicItem/index.tsx
+++ b/src/components/TopicItem/index.tsx
@@ -14,8 +14,8 @@ export const TopicItem: React.VFC<Props> = memo((props) => {
 
   // todo 削除前に確認ダイアログ表示させたい
   const deleteTopic = useCallback(() => {
+    // 管理者ユーザーでなければ削除できない
     if (!authUser.isAdmin) {
-      // 管理者ユーザーでなければ削除できない
       return;
     }
 

--- a/src/components/Topics/index.tsx
+++ b/src/components/Topics/index.tsx
@@ -1,38 +1,15 @@
 import React, { useEffect, useState } from "react";
 import { firebaseDB } from "../../firebase";
 import { TopicItem } from "../TopicItem";
-
-interface Topic {
-  id: string;
-  content: string;
-  timestamp: any;
-}
+import { useTopics } from "../../lib/useTopics";
 
 // 話題一覧画面コンポーネント;
 export const Topics: React.VFC = () => {
-  const [topics, setTopics] = useState<Array<Topic>>([
-    {
-      id: "",
-      content: "",
-      timestamp: null,
-    },
-  ]);
-
   // firestore から topics データ取得
-  useEffect(() => {
-    const unSubscription = firebaseDB
-      .collection("topics")
-      .orderBy("timestamp", "desc")
-      .onSnapshot((snapshot) => {
-        setTopics(
-          snapshot.docs.map<Topic>((doc) => ({
-            id: doc.id,
-            content: doc.data().topic,
-            timestamp: doc.data().timestamp,
-          }))
-        );
-      });
+  const { topics, getTopics } = useTopics();
 
+  useEffect(() => {
+    const unSubscription = getTopics();
     // Firestore の DB情報更新の検知を解除
     return () => unSubscription();
   }, [firebaseDB]);

--- a/src/components/Topics/index.tsx
+++ b/src/components/Topics/index.tsx
@@ -1,18 +1,18 @@
-import React, { useEffect, useState } from "react";
-import { firebaseDB } from "../../firebase";
+import React, { useEffect } from "react";
 import { TopicItem } from "../TopicItem";
 import { useTopics } from "../../lib/useTopics";
 
 // 話題一覧画面コンポーネント;
 export const Topics: React.VFC = () => {
   // firestore から topics データ取得
-  const { topics, getTopics } = useTopics();
+  const { topics, getTopicsFromFirestore } = useTopics();
 
   useEffect(() => {
-    const unSubscription = getTopics();
+    // Firestoreからトピックデータをゲット
+    const unSubscription = getTopicsFromFirestore();
     // Firestore の DB情報更新の検知を解除
     return () => unSubscription();
-  }, [firebaseDB]);
+  }, [getTopicsFromFirestore]);
 
   return (
     <div>

--- a/src/lib/useListenAuthUserState.ts
+++ b/src/lib/useListenAuthUserState.ts
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction } from "react";
 import { firebaseAuth } from "../firebase";
 import { AuthUser } from "../pages/_app";
 
-// todo 型定義
+// ログインユーザーの状態監視関数
 export const useListenAuthUserState = (
   dispatch: Dispatch<SetStateAction<any>>
 ) => {

--- a/src/lib/useTopics.ts
+++ b/src/lib/useTopics.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import { firebaseDB } from "../firebase";
 
-export interface Topic {
+interface Topic {
   id: string;
   content: string;
   timestamp: any;
@@ -17,7 +17,7 @@ export const useTopics = () => {
     } as Topic,
   ]);
 
-  const getTopics = useCallback(() => {
+  const getTopicsFromFirestore = useCallback(() => {
     return firebaseDB
       .collection("topics")
       .orderBy("timestamp", "desc")
@@ -32,5 +32,5 @@ export const useTopics = () => {
       });
   }, [firebaseDB]);
 
-  return { getTopics, topics };
+  return { getTopicsFromFirestore, topics };
 };

--- a/src/lib/useTopics.ts
+++ b/src/lib/useTopics.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from "react";
+import { firebaseDB } from "../firebase";
+
+export interface Topic {
+  id: string;
+  content: string;
+  timestamp: any;
+}
+
+// Topics 取得 hooks
+export const useTopics = () => {
+  const [topics, setTopics] = useState<Array<Topic>>([
+    {
+      id: "",
+      content: "",
+      timestamp: null,
+    } as Topic,
+  ]);
+
+  const getTopics = useCallback(() => {
+    return firebaseDB
+      .collection("topics")
+      .orderBy("timestamp", "desc")
+      .onSnapshot((snapshot) => {
+        setTopics(
+          snapshot.docs.map<Topic>((doc) => ({
+            id: doc.id,
+            content: doc.data().topic,
+            timestamp: doc.data().timestamp,
+          }))
+        );
+      });
+  }, [firebaseDB]);
+
+  return { getTopics, topics };
+};


### PR DESCRIPTION
- カスタムフックを作成
- カスタムフックを一覧表示とシャッフルページで利用


close #61 