### PR TITLE
スクロールのバグ解消、flex-1を設定

### DIFF
--- a/src/components/PageTemplate/index.tsx
+++ b/src/components/PageTemplate/index.tsx
@@ -44,7 +44,7 @@ export const PageTemplate: React.VFC<Props> = memo((props) => {
           <title>{pickTitle(router.pathname)}</title>
         </Head>
         <Header />
-        <div className="flex-grow overflow-y-scroll">{props.children}</div>
+        <div className="flex-1 overflow-y-scroll">{props.children}</div>
         <Footer />
       </div>
     </div>


### PR DESCRIPTION
スマホでスクロールするとバグる、フッターが出ないことを解消

再現できないのでデプロイして実機で検証する